### PR TITLE
Make Fluxus complaint only with security patched Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [3.1, 3.2, 3.3]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
It's sad. I like to support old versions and make the code run with backward compatibility. But outdated code will also make your application suffer in some way. `Fluxus` will try to keep supporting old versions, but we can't promise. Do your best to run at least the oldest supported version you can.