### PR TITLE
Include Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: [3.1, 3.2, 3.3]
+        ruby: [3.1, 3.2, 3.3, 3.4]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Added 2.7 again for now, since we have `~> 2.7` in the Gemfile. It must be deprecated soon.